### PR TITLE
Prevent double save on Enter key by calling blur event on keyup

### DIFF
--- a/template/assets/core.js
+++ b/template/assets/core.js
@@ -584,7 +584,7 @@ Vue.component('cms-quick-edit', {
 Vue.component('cms-quick-edit-text', {
 	props: ['value', 'elementKey'],
 	template: `<b-input-group>
-		<b-form-input v-model="newValue" :id="elementKey" size="sm" @keyup.enter.native="save()" @blur="save()"></b-form-input>
+		<b-form-input v-model="newValue" :id="elementKey" size="sm" @keyup.enter.native="$event.target.blur()" @blur="save()"></b-form-input>
 		<b-input-group-append>
 			<b-button size="sm" type="submit" variant="success" @click="save()">Save</b-button>
 		</b-input-group-append>


### PR DESCRIPTION
- bug fix
- BC break? no

This is a fix for `<cms-quick-edit>`, where the `save()` function was called twice on Enter (Once for Enter, second time for `@blur`).
Fixed by calling the `@blur` event on Enter keyup, while the `@blur` event calls the `save()` function
