### PR TITLE
Removed "You are currently offline" message while loading

### DIFF
--- a/template/@layout.phtml
+++ b/template/@layout.phtml
@@ -75,7 +75,6 @@ use Baraja\Cms\Proxy\Proxy;
 				<table class="w-100">
 					<tr>
 						<td style="width:32px"><b-spinner small></b-spinner></td>
-						<td>You are currently offline, some services may not be available now.</td>
 					</tr>
 				</table>
 			</b-alert>


### PR DESCRIPTION
- new feature
- BC break? yes

Removed the "You are currently offline, some services may not be available now." message while loading website.
